### PR TITLE
[Feat] RecoveryPage 초기 로드 시 전체 음식점 데이터 로드

### DIFF
--- a/src/entities/report/places.ts
+++ b/src/entities/report/places.ts
@@ -48,6 +48,12 @@ export const getPlaces = (params?: GetPlacesParams) => {
   const url = searchParams.toString() 
     ? `/api/v1/places?${searchParams.toString()}`
     : `/api/v1/places`;
+  
+  console.log('getPlaces API 요청:', {
+    url,
+    params,
+    searchParams: searchParams.toString()
+  });
     
   return getResponse(url) as Promise<PlacesResponse>;
 };

--- a/src/features/recovery-zone/components/FilterButtonList.tsx
+++ b/src/features/recovery-zone/components/FilterButtonList.tsx
@@ -142,6 +142,11 @@ export const FilterButtonList = () => {
       places: places.length,
     });
 
+    // selectedRecoveryStatus가 null이면 API 호출하지 않고 context의 전체 데이터 사용
+    if (selectedRecoveryStatus === null) {
+      return;
+    }
+
     if (selectedLocation) {
       setIsLoading(true);
 
@@ -210,7 +215,7 @@ export const FilterButtonList = () => {
         getPlaces({
           lat: selectedLocation.lat,
           lng: selectedLocation.lng,
-          radius: 200, // 200미터 반경
+          radius: 500, // 500미터 반경
           category:
             selectedCategory && selectedCategory !== "전체"
               ? mapFilterToCategory(selectedCategory)
@@ -278,12 +283,12 @@ export const FilterButtonList = () => {
         {FILTER_BUTTONS.map((button, index) => {
           const getSelectedOption = () => {
             if (button.label === "복구현황") {
-              return selectedRecoveryStatus === "전체"
+              return selectedRecoveryStatus === null || selectedRecoveryStatus === "전체"
                 ? undefined
                 : selectedRecoveryStatus;
             }
             if (button.label === "업종") {
-              return selectedCategory === "전체" ? undefined : selectedCategory;
+              return selectedCategory === null || selectedCategory === "전체" ? undefined : selectedCategory;
             }
             return undefined;
           };
@@ -294,9 +299,11 @@ export const FilterButtonList = () => {
             return undefined;
           };
 
-          // 업종 버튼은 복구현황이 "복구완료"가 아닐 때 비활성화
+          // 업종 버튼은 selectedRecoveryStatus가 null이거나 "복구완료"가 아닐 때 비활성화
           const isDisabled =
-            button.label === "업종" && selectedRecoveryStatus !== "복구완료";
+            button.label === "업종" && 
+            (selectedRecoveryStatus === null || 
+             (selectedRecoveryStatus !== null && selectedRecoveryStatus !== "복구완료"));
 
           return (
             <FilterButton
@@ -326,8 +333,9 @@ export const FilterButtonList = () => {
           places.map((place) => {
             // 임시복구나 복구중일 때는 LegacyStoreCard 사용
             if (
-              selectedRecoveryStatus === "임시복구" ||
-              selectedRecoveryStatus === "복구중"
+              selectedRecoveryStatus !== null &&
+              (selectedRecoveryStatus === "임시복구" ||
+              selectedRecoveryStatus === "복구중")
             ) {
               const cardItem = place as any as CardItem; // 타입 캐스팅
               return (

--- a/src/features/sinkhole-map/components/GradeButtonList.tsx
+++ b/src/features/sinkhole-map/components/GradeButtonList.tsx
@@ -22,6 +22,11 @@ export const GradeBottomInner = () => {
     setSearchedDistrict(null);
     setIsBadgeActive(false);
     
+    // 등급 선택시 바텀시트를 100vh로 확장
+    if ((window as any).setBottomSheetHeight) {
+      (window as any).setBottomSheetHeight(100);
+    }
+    
     setSelectedGrade(grade);
     console.log(`${grade}등급 클릭됨`);
     

--- a/src/shared/components/NoticeBar.tsx
+++ b/src/shared/components/NoticeBar.tsx
@@ -16,7 +16,7 @@ const RECOVERY_MESSAGES: Record<string, string> = {
 export const NoticeBar = ({ className = "" }: NoticeBarProps) => {
   let selectedStatus = "전체";
   try {
-    selectedStatus = useRecovery().selectedRecoveryStatus;
+    selectedStatus = useRecovery().selectedRecoveryStatus ?? "전체";
   } catch {
     // RecoveryProvider가 없는 경우 기본 메시지 사용
   }

--- a/src/shared/components/PageHeader.tsx
+++ b/src/shared/components/PageHeader.tsx
@@ -1,5 +1,11 @@
 // PageHeader.tsx
-import { useState, useEffect, useRef, type ReactNode, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  type ReactNode,
+  useCallback,
+} from "react";
 import style from "styled-components";
 import * as BasicElement from "@shared/ui/BasicElement";
 import { MainElement } from "@features/recovery-zone/ui";
@@ -62,7 +68,7 @@ const CouponContent = style(BasicElement.Container).attrs(() => ({
     width: 260px;
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
     gap: 15px;
     border-bottom: 3px dashed #E1E1E1;
@@ -92,7 +98,9 @@ export const PageHeader = ({
   // 토스트 상태
   const [showToastMessage, setShowToastMessage] = useState(false);
   const [isToastExiting, setIsToastExiting] = useState(false);
-  const [toastFilterType, setToastFilterType] = useState<"임시복구" | "복구중">("임시복구");
+  const [toastFilterType, setToastFilterType] = useState<"임시복구" | "복구중">(
+    "임시복구"
+  );
   const [lastShownStatus, setLastShownStatus] = useState<string | null>(null);
 
   // 타이머 ref (중복 실행/메모리 누수 방지)
@@ -117,25 +125,34 @@ export const PageHeader = ({
     const couponContext = useCoupon();
     couponModalPlace = couponContext.couponModalPlace;
     closeCouponModal = couponContext.closeCouponModal;
-  } catch { /* Provider 미존재시 무시 */ }
+  } catch {
+    /* Provider 미존재시 무시 */
+  }
 
   // RecoveryContext (토스트용)
   let selectedRecoveryStatus: string = "전체";
   try {
     if (showToast) {
       const recoveryContext = useRecovery();
-      selectedRecoveryStatus = recoveryContext.selectedRecoveryStatus;
+      selectedRecoveryStatus = recoveryContext.selectedRecoveryStatus ?? "전체";
     }
-  } catch { /* Provider 미존재시 무시 */ }
+  } catch {
+    /* Provider 미존재시 무시 */
+  }
 
   // 복구현황 변경 → 토스트 표시/종료 스케줄링
   useEffect(() => {
     clearTimers();
 
     const isToastTarget =
-      selectedRecoveryStatus === "임시복구" || selectedRecoveryStatus === "복구중";
+      selectedRecoveryStatus === "임시복구" ||
+      selectedRecoveryStatus === "복구중";
 
-    if (showToast && isToastTarget && selectedRecoveryStatus !== lastShownStatus) {
+    if (
+      showToast &&
+      isToastTarget &&
+      selectedRecoveryStatus !== lastShownStatus
+    ) {
       // 기존 토스트 정리 후 새 토스트 준비
       setShowToastMessage(false);
       setIsToastExiting(false);
@@ -166,7 +183,9 @@ export const PageHeader = ({
   let sinkholeContext: any = null;
   try {
     if (showSinkholeButton) sinkholeContext = useSelectGrade();
-  } catch { /* Provider 미존재시 무시 */ }
+  } catch {
+    /* Provider 미존재시 무시 */
+  }
 
   const handleButtonClick = async (type: "badge" | "layer") => {
     setActiveButton(type);
@@ -176,7 +195,7 @@ export const PageHeader = ({
       sinkholeContext.setSelectedGradeData(null);
       sinkholeContext.setSelectedGrade(null);
       sinkholeContext.setSearchedDistrict(null);
-      
+
       sinkholeContext.setIsBadgeActive(true);
       try {
         const response = await getSafezoneGu();
@@ -244,12 +263,12 @@ export const PageHeader = ({
             {SinkholeMainElement.SinkholeButton(
               "layer",
               activeButton === "layer",
-              () => handleButtonClick("layer"),
+              () => handleButtonClick("layer")
             )}
             {SinkholeMainElement.SinkholeButton(
               "badge",
               activeButton === "badge",
-              () => handleButtonClick("badge"),
+              () => handleButtonClick("badge")
             )}
           </div>
         )}
@@ -280,27 +299,44 @@ export const PageHeader = ({
               />
             </div>
 
-            <div style={{ display: "flex", gap: "30px", flexDirection: "column" }}>
+            <div
+              style={{ display: "flex", gap: "30px", flexDirection: "column" }}
+            >
               <div id="notice">
-                <img src={logo} alt="로고" style={{ width: "77.25px", height: "36px" }} />
+                <img
+                  src={logo}
+                  alt="로고"
+                  style={{ width: "77.25px", height: "36px" }}
+                />
               </div>
 
               <div id="coupon-wrapper">
-                <div className="coupon-title">카페 미묘 10% 할인쿠폰</div>
-                <p className="content">쿠폰 발급 및 사용 기간 : 2025.07.01 ~ 07.31</p>
+                <div className="coupon-title">
+                  {couponModalPlace?.name || "카페 미묘"}{" "}
+                </div>
+                <div className="coupon-title">10% 할인쿠폰</div>
+                <p className="content">
+                  쿠폰 발급 및 사용 기간 : 2025.07.01 ~ 07.31
+                </p>
               </div>
 
               <div
-                style={{ display: "flex", justifyContent: "center", paddingBottom: "25px" }}
+                style={{
+                  display: "flex",
+                  justifyContent: "center",
+                  paddingBottom: "25px",
+                }}
               >
                 <Barcode
-                  data={`COUPON-${couponModalPlace?.name || "DEFAULT"}-${Date.now()}`}
+                  data={`COUPON-${
+                    couponModalPlace?.name || "DEFAULT"
+                  }-${Date.now()}`}
                   width={200}
                   height={60}
                   showText={true}
-                  text={`${String(couponModalPlace?.name?.slice(0, 3) || "001")}-${String(
-                    Date.now(),
-                  ).slice(-6)}`}
+                  text={`${String(
+                    couponModalPlace?.name?.slice(0, 3) || "001"
+                  )}-${String(Date.now()).slice(-6)}`}
                   barColor="#333"
                   backgroundColor="transparent"
                 />


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

- RecoveryPage에서 초기 로드 시 음식점 데이터를 전부 가져오도록 했습니다.
- 이후 위치 설정 버튼을 통해 위치 정보 수집을 허용하면 해당 위치를 기준으로 데이터를 가져옵니다.

## 💡 참고 사항

<!-- 참고할 사항 (없다면 삭제) -->

## 📸 스크린샷

| 구현 내용 |            390px            |            375px            |            320px            |
| :-------: | :-------------------------: | :-------------------------: | :-------------------------: |
|    IMG    | <img width="390" height="817" alt="image" src="https://github.com/user-attachments/assets/24c47114-28e6-48cd-80a5-d75e7dea2026" /> | <img width="378" height="813" alt="image" src="https://github.com/user-attachments/assets/5a05d635-f639-4b52-83fd-b860bbd78aee" /> | <img width="324" height="812" alt="image" src="https://github.com/user-attachments/assets/4e34a47e-4fdc-4547-8286-4a79c5434c19" /> |

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명 -->

`RecoveryContext`

- 초기 selectedRecoveryStatus와 selectedCategory는 모두 null

```typescript
interface RecoveryContextType {
  // 선택된 위치 정보
  selectedLocation: LocationData | null;
  setSelectedLocation: (location: LocationData | null) => void;
  
  // 주변 장소 데이터
  places: Place[];
  setPlaces: (places: Place[]) => void;
  
  // 로딩 상태
  isLoading: boolean;
  setIsLoading: (loading: boolean) => void;
  
  // 필터 상태
  selectedRecoveryStatus: string | null;
  setSelectedRecoveryStatus: (status: string | null) => void;
  selectedCategory: string | null;
  setSelectedCategory: (category: string | null) => void;
}
```

`FilterButton`

- context의 selectedRecoveryStatus가 null일 경우 초기에 로드한 모든 장소 데이터 출력
```typescript
  // 장소 데이터 불러오기 (복구현황에 따라 다른 API 호출)
  useEffect(() => {
    console.log("useEffect 실행:", {
      selectedLocation,
      selectedRecoveryStatus,
      selectedCategory,
      places: places.length,
    });

    // selectedRecoveryStatus가 null이면 API 호출하지 않고 context의 전체 데이터 사용
    if (selectedRecoveryStatus === null) {
      return;
    }
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 영향을 주지 않음
- [x] 린트/포맷팅 적용 완료
- [x] 관련 테스트 작성 또는 기존 테스트 통과 확인
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 포함됨

## 📟 관련 이슈

- Resolves: #이슈해결
- Related to: #37
